### PR TITLE
feat: 回测参数可保存为自定义策略并新增订单流回调策略，实盘执行兼容 BaseStrategy/on_bar

### DIFF
--- a/Trading/live_trader.py
+++ b/Trading/live_trader.py
@@ -12,6 +12,8 @@ import requests
 import pandas as pd
 
 from app_logger.logger_setup import Logger
+from core.constants import PositionSide, SignalType
+from Strategy.base import Bar, Position as StrategyPosition, StrategyContext
 
 logger = Logger(__name__)
 
@@ -384,24 +386,36 @@ class LiveTrader:
             return
         
         try:
+            strategy_params = self._strategy.get_parameters() if hasattr(self._strategy, "get_parameters") else {}
+            auto_select = str(strategy_params.get("auto_select_symbol", "true")).lower() == "true"
+            if self._strategy.__class__.__name__ == "OrderFlowPullbackStrategy" and auto_select:
+                selected_symbol = self._pick_volatile_symbol()
+                if selected_symbol and selected_symbol != self.config.symbol:
+                    self.config.symbol = selected_symbol
+                    logger.info(f"订单流策略自动选币: {selected_symbol}")
+
             data = self._get_klines(self.config.symbol, limit=200)
             
             if data is None or len(data) < 50:
                 return
             
+            if hasattr(self._strategy, "on_bar"):
+                self._execute_base_strategy(data)
+                return
+
             signal = self._strategy.generate_signal(data)
-            
+
             if signal is None:
                 return
-            
+
             current_position = self._positions.get(self.config.symbol)
-            
+
             if signal == 1:
                 if current_position and current_position.side == "short":
                     self._close_position(self.config.symbol)
                 if not current_position or current_position.side != "long":
                     self._open_position(self.config.symbol, "long")
-                    
+
             elif signal == -1:
                 if current_position and current_position.side == "long":
                     self._close_position(self.config.symbol)
@@ -412,7 +426,114 @@ class LiveTrader:
             logger.error(f"策略执行错误: {e}")
             if self._error_callback:
                 self._error_callback(f"策略执行错误: {e}")
+
+    def _execute_base_strategy(self, data: pd.DataFrame) -> None:
+        """执行 BaseStrategy 接口策略"""
+        strategy = self._strategy
+        symbol = self.config.symbol
+
+        if not hasattr(strategy, "_live_initialized"):
+            strategy._live_initialized = False
+
+        current_position = self._positions.get(symbol)
+        if current_position is None:
+            strategy_position = StrategyPosition(
+                side=PositionSide.EMPTY,
+                quantity=0.0,
+                entry_price=0.0,
+                entry_time=datetime.now(),
+            )
+        else:
+            side_map = {"long": PositionSide.LONG, "short": PositionSide.SHORT}
+            strategy_position = StrategyPosition(
+                side=side_map.get(current_position.side, PositionSide.EMPTY),
+                quantity=current_position.quantity,
+                entry_price=current_position.entry_price,
+                entry_time=datetime.now(),
+                unrealized_pnl=current_position.unrealized_pnl,
+            )
+
+        row = data.iloc[-1]
+        bar = Bar(
+            timestamp=data.index[-1].to_pydatetime() if hasattr(data.index[-1], "to_pydatetime") else datetime.now(),
+            open=float(row["open"]),
+            high=float(row["high"]),
+            low=float(row["low"]),
+            close=float(row["close"]),
+            volume=float(row["volume"]),
+            symbol=symbol,
+            interval=self.config.interval,
+        )
+
+        context = StrategyContext(
+            symbol=symbol,
+            interval=self.config.interval,
+            position=strategy_position,
+            equity=self._account.balance + self._account.unrealized_pnl,
+            available_capital=self._account.available,
+            current_price=bar.close,
+            timestamp=bar.timestamp,
+            data_count=len(data),
+        )
+
+        if not strategy._live_initialized:
+            strategy.initialize(context)
+            strategy._live_initialized = True
+
+        result = strategy.on_bar(bar, context)
+        signal = result.signal if result else None
+        if not signal:
+            return
+
+        if signal.type == SignalType.OPEN_LONG:
+            if current_position and current_position.side == "short":
+                self._close_position(symbol)
+            self._open_position(symbol, "long")
+        elif signal.type == SignalType.OPEN_SHORT:
+            if current_position and current_position.side == "long":
+                self._close_position(symbol)
+            self._open_position(symbol, "short")
+        elif signal.type == SignalType.CLOSE_LONG and current_position and current_position.side == "long":
+            self._close_position(symbol)
+        elif signal.type == SignalType.CLOSE_SHORT and current_position and current_position.side == "short":
+            self._close_position(symbol)
     
+    def _pick_volatile_symbol(self) -> str | None:
+        """自动选择高波动USDT交易对"""
+        try:
+            if self.config.mode == TradingMode.TEST:
+                return self.config.symbol
+
+            response = requests.get(f"{self._base_url}/fapi/v1/ticker/24hr", timeout=10)
+            if response.status_code != 200:
+                return None
+
+            tickers = response.json()
+            candidates = []
+            for t in tickers:
+                symbol = t.get("symbol", "")
+                if not symbol.endswith("USDT"):
+                    continue
+                if any(x in symbol for x in ("UPUSDT", "DOWNUSDT", "BULL", "BEAR")):
+                    continue
+                try:
+                    change_pct = abs(float(t.get("priceChangePercent", 0)))
+                    quote_volume = float(t.get("quoteVolume", 0))
+                except Exception:
+                    continue
+                if quote_volume < 5_000_000:
+                    continue
+                candidates.append((change_pct, quote_volume, symbol))
+
+            if not candidates:
+                return None
+
+            candidates.sort(reverse=True)
+            return candidates[0][2]
+        except Exception as e:
+            logger.warning(f"自动选币失败: {e}")
+            return None
+
     def _get_klines(self, symbol: str, limit: int = 200) -> pd.DataFrame | None:
         """获取K线数据"""
         try:
@@ -699,9 +820,9 @@ class LiveTrader:
         order.update_time = datetime.now()
         
         if order.side == OrderSide.BUY:
-            self._open_position(order)
+            self._open_position_from_order(order)
         else:
-            self._close_position(order)
+            self._close_position_from_order(order)
     
     def _submit_order(self, order: Order) -> None:
         """提交订单到交易所"""
@@ -711,11 +832,11 @@ class LiveTrader:
         order.update_time = datetime.now()
         
         if order.side == OrderSide.BUY:
-            self._open_position(order)
+            self._open_position_from_order(order)
         else:
-            self._close_position(order)
+            self._close_position_from_order(order)
     
-    def _open_position(self, order: Order) -> None:
+    def _open_position_from_order(self, order: Order) -> None:
         """开仓"""
         symbol = order.symbol
         
@@ -739,7 +860,7 @@ class LiveTrader:
         
         logger.info(f"开仓: {symbol} {position.quantity} @ {position.entry_price}")
     
-    def _close_position(self, order: Order) -> None:
+    def _close_position_from_order(self, order: Order) -> None:
         """平仓"""
         symbol = order.symbol
         


### PR DESCRIPTION
### Motivation
- 将回测与实盘参数打通，支持将最优回测参数保存为可在实盘直接加载运行的自定义策略，以便快速部署并复用回测成果。 
- 增加面向订单流的自动化策略，自动筛选高波动币种并实现顺势小步加仓、一次回调止盈的交易逻辑，扩展实盘能力。 
- 使实盘引擎兼容新的策略接口（`BaseStrategy.on_bar` + `StrategyContext`），提高策略编码统一性和回测/实盘的一致性。

### Description
- 在 `UI/main_ui.py` 中增加自定义策略保存/加载与实盘参数联通支持，包括：添加 `保存为自定义策略` 按钮、`自定义策略` 下拉与 `加载` 按钮、动态实盘策略参数面板、会话保存/恢复对实盘策略参数的持久化，以及回测同步到实盘时的参数映射与应用（新增 `_collect_live_strategy_params`、`_apply_live_strategy_params`、`_save_as_custom_strategy`、`_load_custom_strategy_to_live` 等方法）。
- 在 `Strategy/templates/__init__.py` 中新增 `OrderFlowPullbackStrategy`（订单流回调策略），并将其注册到策略工厂；策略支持参数 `auto_select_symbol`、`momentum_bars`、`volume_ratio`、`add_position_pct`、`pullback_take_profit_pct`，实现“连阳+量能放大开仓，记录峰值、回调止盈”逻辑。 
- 在 `Trading/live_trader.py` 中增强实盘执行：对接 `BaseStrategy` 风格的 `on_bar(bar, context)` 执行路径（新增 `_execute_base_strategy`），在实盘启动时将 UI 参数注入策略实例；为 `OrderFlowPullbackStrategy` 增加自动选币逻辑（通过 24h ticker 筛选高波动且有成交量的 USDT 币种，方法 `_pick_volatile_symbol`）并在满足条件时自动切换 `self.config.symbol`；调整订单执行分支以使用新方法名 `_open_position_from_order` / `_close_position_from_order` 来处理 `Order` 对象。 
- 小幅 UI 映射与兼容修正：同步回测结果到实盘时正确映射策略显示名与内部策略 key，并在回测完成后允许保存为自定义策略。 

### Testing
- 编译检查：运行 `python -m py_compile UI/main_ui.py Trading/live_trader.py Strategy/templates/__init__.py`，结果通过并无语法错误。 ✅
- 静态解析：使用 `ast.parse` 对修改后文件进行解析，未抛异常。 ✅
- 单元测试：执行 `pytest -q test_ui_import.py test_trade_mode_sync.py` 时测试收集阶段因环境缺少 `pandas` 导致失败（测试未能运行到断言阶段），问题为测试环境依赖缺失而非代码语法错误。 ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997f7019a8483248c6e90ffd5c965c5)