### PR TITLE
feat: 完善订单流策略参数与回测/参数优化配置并补充 UI 参数说明

### DIFF
--- a/Strategy/parameter_optimizer.py
+++ b/Strategy/parameter_optimizer.py
@@ -1063,7 +1063,7 @@ class ParameterOptimizer:
             risk_params = {}
             
             for key, value in params.items():
-                if key in ["leverage", "stop_loss_pct", "take_profit_pct", "position_size"]:
+                if key in ["leverage", "stop_loss_pct", "take_profit_pct", "position_size", "commission_rate", "slippage"]:
                     risk_params[key] = value
                 else:
                     strategy_params[key] = value
@@ -1078,8 +1078,8 @@ class ParameterOptimizer:
                 position_size=risk_params.get("position_size", self.base_config.position_size),
                 stop_loss_pct=risk_params.get("stop_loss_pct", self.base_config.stop_loss_pct),
                 take_profit_pct=risk_params.get("take_profit_pct", self.base_config.take_profit_pct),
-                commission_rate=self.base_config.commission_rate,
-                slippage=self.base_config.slippage,
+                commission_rate=float(risk_params.get("commission_rate", self.base_config.commission_rate)),
+                slippage=float(risk_params.get("slippage", self.base_config.slippage)),
             )
             
             engine = BacktestEngine(strategy, config)
@@ -1265,6 +1265,22 @@ def get_all_optimizable_params(
                 step=0.05,
                 category="risk",
                 display_name="仓位比例",
+            ),
+            ParameterRange(
+                name="commission_rate",
+                min_value=0.0,
+                max_value=0.002,
+                step=0.0002,
+                category="risk",
+                display_name="手续费率",
+            ),
+            ParameterRange(
+                name="slippage",
+                min_value=0.0,
+                max_value=0.002,
+                step=0.0002,
+                category="risk",
+                display_name="滑点率",
             ),
         ]
     


### PR DESCRIPTION
### Motivation
- 提升订单流策略的可配置性与风控能力，使回测与参数优化更贴近实盘（支持追踪止盈、硬止损、加仓限制、冷却等）。
- 将交易执行成本（手续费/滑点）纳入参数优化与回测配置，减少回测到实盘的偏差。
- 在 UI 中提供清晰的参数说明与可交互控件，降低配置门槛并支持高自由度参数搜索。

### Description
- 在 `Strategy/templates/__init__.py` 中为 `OrderFlowPullbackStrategy` 增加并暴露多个高自定义参数：`trail_activation_pct`、`trailing_stop_pct`、`hard_stop_loss_pct`、`max_add_count`、`add_size_decay`、`momentum_add_boost`、`cooldown_bars`，并实现对应逻辑（硬止损、追踪止盈、加仓衰减/次数限制、平仓冷却），以及动态 `get_required_data_count()`。 
- 在 `Strategy/parameter_optimizer.py` 中将 `commission_rate` 与 `slippage` 纳入可优化的风险参数，并在评估时把它们注入到 `BacktestConfig` 中用于回测评估。 
- 在 `UI/main_ui.py` 中扩展回测与优化界面：回测面板新增 `手续费率` 和 `滑点率` 控件，回测/优化任务将这两项参数传递并作为优化基准；参数范围表扩展为 5 列（新增“说明”列），展示参数的 `display_name` 并保留内部参数名映射；回测策略配置区新增一个只读的“参数说明”文本块，自动展示策略说明、最小数据需求和每个参数的描述/默认/范围。 
- 修正并增强参数表与优化流程之间的名称映射（参数表展示名 -> 内部参数名）以确保优化器读取到正确的键名。 
- 新增单元测试 `tests/test_orderflow_pullback_strategy.py::test_orderflow_pullback_strategy_hard_stop_and_cooldown_work` 用于覆盖硬止损与冷却逻辑触发路径。 

### Testing
- 对本次变更的文件执行语法检查：`python -m py_compile Strategy/templates/__init__.py UI/main_ui.py Strategy/parameter_optimizer.py tests/test_orderflow_pullback_strategy.py`，编译检查通过。 
- 尝试运行相关 pytest：`pytest -q tests/test_orderflow_pullback_strategy.py`，测试收集阶段因当前环境缺少 `pandas` 报错（环境依赖问题），非逻辑回归错误。 
- 生成并保存了 UI 截图以验证界面改动（截图已产出于运行环境的 artifacts）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699849fe2a988324b0ded4458278241b)