### PR TITLE
新增订单流-薅羊毛策略，更新订单流-追涨文案并修复参数优化浮点步长问题

### DIFF
--- a/Trading/live_trader.py
+++ b/Trading/live_trader.py
@@ -388,7 +388,7 @@ class LiveTrader:
         try:
             strategy_params = self._strategy.get_parameters() if hasattr(self._strategy, "get_parameters") else {}
             auto_select = str(strategy_params.get("auto_select_symbol", "true")).lower() == "true"
-            if self._strategy.__class__.__name__ == "OrderFlowPullbackStrategy" and auto_select:
+            if self._strategy.__class__.__name__ in {"OrderFlowPullbackStrategy", "OrderFlowWoolStrategy"} and auto_select:
                 selected_symbol = self._pick_volatile_symbol()
                 if selected_symbol and selected_symbol != self.config.symbol:
                     self.config.symbol = selected_symbol

--- a/UI/main_ui.py
+++ b/UI/main_ui.py
@@ -606,7 +606,8 @@ class TradingUI(QMainWindow):
         "布林带策略": "BollingerBandsStrategy",
         "多指标组合策略": "MultiIndicatorStrategy",
         "自适应多指标策略": "AdaptiveMultiIndicatorStrategy",
-        "订单流回调策略": "OrderFlowPullbackStrategy",
+        "订单流-追涨策略": "OrderFlowPullbackStrategy",
+        "订单流-薅羊毛策略": "OrderFlowWoolStrategy",
     }
     
     SYMBOLS = ["BTCUSDT", "ETHUSDT", "SOLUSDT", "BNBUSDT", "XRPUSDT", "DOGEUSDT", "ADAUSDT", "AVAXUSDT", "TRXUSDT", "LINKUSDT", "LTCUSDT", "BCHUSDT", "MATICUSDT", "WIFUSDT", "PEPEUSDT", "1000BONKUSDT", "SUIUSDT", "APTUSDT", "ARBUSDT", "OPUSDT"]

--- a/backtest/engine.py
+++ b/backtest/engine.py
@@ -523,6 +523,44 @@ class BacktestEngine:
             )
         
         elif signal.type == SignalType.OPEN_SHORT:
+            if self._position.is_open and self._position.side == PositionSide.SHORT:
+                add_pct = float(signal.extra.get("add_position_pct", 0.0)) if signal.extra else 0.0
+                if add_pct <= 0:
+                    return
+
+                add_qty = self._calculate_position_size(bar.close) * add_pct
+                if add_qty <= 0:
+                    return
+
+                old_qty = self._position.quantity
+                new_qty = old_qty + add_qty
+                new_entry = (
+                    self._position.entry_price * old_qty + bar.close * add_qty
+                ) / new_qty
+
+                commission = add_qty * bar.close * self.config.commission_rate
+                self._capital -= commission
+
+                self._position.quantity = new_qty
+                self._position.entry_price = new_entry
+
+                self._trade_id += 1
+                self._trades.append(
+                    Trade(
+                        trade_id=self._trade_id,
+                        timestamp=timestamp,
+                        symbol=self.config.symbol,
+                        side="ADD_SHORT",
+                        quantity=add_qty,
+                        price=bar.close,
+                        commission=commission,
+                        reason=signal.reason,
+                        stop_loss=self._position.stop_loss,
+                        take_profit=self._position.take_profit,
+                    )
+                )
+                return
+
             if self._position.is_open:
                 return
             

--- a/tests/test_orderflow_pullback_strategy.py
+++ b/tests/test_orderflow_pullback_strategy.py
@@ -75,3 +75,39 @@ def test_orderflow_pullback_strategy_hard_stop_and_cooldown_work():
 
     hard_stop_exits = [t for t in result.completed_trades if "硬止损" in t.reason]
     assert len(hard_stop_exits) >= 1
+
+
+def test_orderflow_wool_strategy_can_add_short_and_close_on_pullback():
+    strategy = get_strategy("OrderFlowWoolStrategy", {
+        "momentum_bars": 3,
+        "overbought_rsi": 60,
+        "min_volume_ratio": 0.8,
+        "max_volume_ratio": 5.0,
+        "base_add_position_pct": 20.0,
+        "base_price_gap_pct": 0.1,
+        "momentum_gap_boost": 0.1,
+        "pullback_take_profit_pct": 0.8,
+    })
+
+    prices = [100 + i * 0.4 for i in range(30)] + [112.0, 112.4, 112.9, 113.5, 112.1, 111.3]
+    rows = []
+    for i, close in enumerate(prices):
+        rows.append({
+            "open": close * 0.999,
+            "high": close * 1.003,
+            "low": close * 0.997,
+            "close": close,
+            "volume": 2200 + i * 15,
+        })
+
+    data = pd.DataFrame(rows, index=pd.date_range(datetime(2024, 3, 1), periods=len(rows), freq="30min"))
+
+    engine = BacktestEngine(
+        strategy,
+        BacktestConfig(symbol="DOGEUSDT", interval="30min", initial_capital=10000, position_size=1.0),
+    )
+    result = engine.run(data)
+
+    add_trades = [t for t in result.trades if t.side == "ADD_SHORT"]
+    assert len(add_trades) >= 1
+    assert any(t.side == "short" for t in result.completed_trades)

--- a/tests/test_parameter_optimizer.py
+++ b/tests/test_parameter_optimizer.py
@@ -32,6 +32,12 @@ class TestParameterRange:
         assert len(values) == 5
         assert values[0] == 0.0
         assert values[-1] == 1.0
+
+    def test_get_values_avoids_floating_point_drift(self):
+        pr = ParameterRange("gap", 0.05, 2.0, 0.195)
+        values = pr.get_values()
+        assert all(abs(v) < 100 for v in values if isinstance(v, (int, float)))
+        assert abs(float(values[-1]) - 2.0) < 1e-8
     
     def test_get_values_with_explicit_values(self):
         pr = ParameterRange("type", 0, 0, values=["A", "B", "C"])


### PR DESCRIPTION
### Motivation
- 实现新的“订单流-薅羊毛”策略，按动量与量能在超买区分批做空并在回撤/追踪触发时平仓以实现短线薅毛收益。 
- 将现有“订单流回调策略”对外文案调整为“订单流-追涨策略”以更贴合其顺势追涨设计并保持类名兼容。 
- 修复参数优化模块中浮点步长累加导致的数值漂移与异常初始步长问题，提升网格/随机等搜索稳定性。 

### Description
- 新增策略 `OrderFlowWoolStrategy`（文件 `Strategy/templates/__init__.py`），实现：自动/可选筛选高波动且量能合适的交易对、在超买区分批做空、按动量动态计算加仓价差、支持加仓衰减、回调/追踪止盈、硬止损与冷却期，并注册到 `STRATEGY_REGISTRY`。 
- 将 `OrderFlowPullbackStrategy` 的展示名称与描述调整为“订单流-追涨策略”，并将若干日志/理由文字改为“追涨”前缀以区分行为（保留类名以兼容旧配置）。 
- 回测引擎（`backtest/engine.py`）增加对空头加仓的处理逻辑：当已有空头仓位且收到 `OPEN_SHORT` 带 `extra.add_position_pct` 时生成 `ADD_SHORT` 交易并重算持仓均价与手续费。 
- 实盘交易器（`Trading/live_trader.py`）将自动选币逻辑扩展到同时支持 `OrderFlowPullbackStrategy` 与 `OrderFlowWoolStrategy`（根据策略参数 `auto_select_symbol`）。 
- 参数优化器（`Strategy/parameter_optimizer.py`）中 `ParameterRange.get_values()` 重写为基于计算步数生成、统一舍入并在必要时补上上界，避免累加误差；从策略推导浮点参数范围时对默认步长做安全舍入与下限保护（避免异常大/高精度步长）。 
- UI（`UI/main_ui.py`）策略列表加入“订单流-薅羊毛策略”。 
- 新增/更新单元测试：`tests/test_orderflow_pullback_strategy.py` 增加 `test_orderflow_wool_strategy_can_add_short_and_close_on_pullback`，`tests/test_parameter_optimizer.py` 增加 `test_get_values_avoids_floating_point_drift`。 

### Testing
- 语法/静态校验：对关键模块执行 `python -m py_compile`，所有目标文件语法检查通过。 
- 单元测试（部分）：新增测试已添加到 `tests/`，尝试运行 `pytest -q tests/test_orderflow_pullback_strategy.py tests/test_parameter_optimizer.py` 但测试收集阶段因运行环境缺少 `pandas` 导致失败（这是环境依赖问题，而非代码逻辑失败）。 
- 本地行为验证：已通过编辑/编译检查和回测引擎逻辑演练（新增空头加仓分支、实盘自动选币分支）进行基本验证，新增测试将在包含 `pandas` 的环境中通过执行以确认策略与步长修复的运行结果。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998589253ac83249deeb98190a73162)