### PR TITLE
feat: support 1s/5s/15s backtests and realtime orderflow simulation (testnet)

### DIFF
--- a/Strategy/parameter_optimizer.py
+++ b/Strategy/parameter_optimizer.py
@@ -1223,6 +1223,11 @@ def get_parameter_ranges_from_strategy(
             max_val = param.max_value if param.max_value is not None else param.default_value * 2
             raw_step = (max_val - min_val) / 10 if max_val is not None and min_val is not None else 0.1
             step = max(1e-6, round(float(raw_step), 6))
+
+            # 对订单流类细粒度百分比参数采用更小步长，提升回测/优化稳定性
+            if any(k in param.name for k in ("_pct", "_ratio", "_boost")):
+                step = min(step, 0.1)
+
             ranges.append(ParameterRange(
                 name=param.name,
                 min_value=min_val,

--- a/UI/main_ui.py
+++ b/UI/main_ui.py
@@ -616,12 +616,13 @@ class TradingUI(QMainWindow):
     
     SYMBOLS = ["BTCUSDT", "ETHUSDT", "SOLUSDT", "BNBUSDT", "XRPUSDT", "DOGEUSDT", "ADAUSDT", "AVAXUSDT", "TRXUSDT", "LINKUSDT", "LTCUSDT", "BCHUSDT", "MATICUSDT", "WIFUSDT", "PEPEUSDT", "1000BONKUSDT", "SUIUSDT", "APTUSDT", "ARBUSDT", "OPUSDT"]
     
-    INTERVALS = ["1min", "5min", "15min", "30min", "1h", "4h", "1d"]
+    INTERVALS = ["1s", "5s", "15s", "1min", "5min", "15min", "30min", "1h", "4h", "1d"]
     
     INDICATOR_OPTIONS = ["MACD", "RSI", "BollingerBands", "MA"]
     
     def __init__(self):
         super().__init__()
+        self._compact_mode = False
         self._worker = None
         self._optimizer_worker = None
         self._last_result = None
@@ -641,6 +642,7 @@ class TradingUI(QMainWindow):
     def _init_ui(self):
         self.setWindowTitle("量化交易系统 v2.0")
         self.setGeometry(80, 80, 1500, 900)
+        self.setMinimumSize(980, 620)
         self.setStyleSheet(self._stylesheet())
         
         central = QWidget()
@@ -665,6 +667,38 @@ class TradingUI(QMainWindow):
         self._ui_log_timer = QTimer(self)
         self._ui_log_timer.timeout.connect(self._flush_ui_logs)
         self._ui_log_timer.start(150)
+
+        self._apply_window_mode()
+
+    def _toggle_compact_mode(self):
+        """切换小窗模式"""
+        self._compact_mode = not self._compact_mode
+        self._apply_window_mode()
+
+    def _apply_window_mode(self):
+        """应用窗口尺寸与标签显示模式"""
+        if not hasattr(self, "main_tabs"):
+            return
+
+        tab_texts = [
+            "📊 回测",
+            "🔍 参数探索",
+            "⚙️ 策略参数",
+            "💹 实盘交易",
+            "📈 资产曲线",
+            "📝 版本更新",
+        ]
+        compact_texts = ["📊", "🔍", "⚙️", "💹", "📈", "📝"]
+        for i in range(min(self.main_tabs.count(), len(tab_texts))):
+            self.main_tabs.setTabText(i, compact_texts[i] if self._compact_mode else tab_texts[i])
+
+        if hasattr(self, "compact_btn"):
+            self.compact_btn.setText("🖥️ 标准窗口" if self._compact_mode else "🪟 小窗模式")
+
+        if self._compact_mode:
+            self.resize(1080, 680)
+        else:
+            self.resize(1500, 900)
     
     def _show_env_load_result(self) -> None:
         """显示API密钥加载结果"""
@@ -3166,7 +3200,21 @@ class TradingUI(QMainWindow):
         layout.addWidget(title)
         
         layout.addStretch()
-        
+
+        self.compact_btn = QPushButton("🪟 小窗模式")
+        self.compact_btn.setStyleSheet("""
+            QPushButton {
+                background-color: #2a2e39;
+                color: #eaecef;
+                border-radius: 6px;
+                padding: 6px 12px;
+                font-size: 12px;
+            }
+            QPushButton:hover { background-color: #363a45; }
+        """)
+        self.compact_btn.clicked.connect(self._toggle_compact_mode)
+        layout.addWidget(self.compact_btn)
+
         self.status = QLabel("● 就绪")
         self.status.setStyleSheet("color: #0ecb81; font-size: 13px;")
         layout.addWidget(self.status)
@@ -3419,7 +3467,21 @@ class TradingUI(QMainWindow):
         layout.addWidget(title)
         
         layout.addStretch()
-        
+
+        self.compact_btn = QPushButton("🪟 小窗模式")
+        self.compact_btn.setStyleSheet("""
+            QPushButton {
+                background-color: #2a2e39;
+                color: #eaecef;
+                border-radius: 6px;
+                padding: 6px 12px;
+                font-size: 12px;
+            }
+            QPushButton:hover { background-color: #363a45; }
+        """)
+        self.compact_btn.clicked.connect(self._toggle_compact_mode)
+        layout.addWidget(self.compact_btn)
+
         self.status = QLabel("● 就绪")
         self.status.setStyleSheet("color: #0ecb81;")
         layout.addWidget(self.status)

--- a/tests/test_live_strategy_health.py
+++ b/tests/test_live_strategy_health.py
@@ -1,0 +1,15 @@
+from Trading.live_trader import LiveTrader, TradingConfig, TradingMode
+from Strategy.templates import STRATEGY_REGISTRY
+from Strategy.multi_indicator_strategy import MultiIndicatorStrategy, AdaptiveMultiIndicatorStrategy
+
+
+def test_all_strategies_pass_live_runtime_health_check():
+    trader = LiveTrader(TradingConfig(mode=TradingMode.TEST))
+
+    strategy_classes = list(STRATEGY_REGISTRY.values()) + [MultiIndicatorStrategy, AdaptiveMultiIndicatorStrategy]
+
+    for strategy_class in strategy_classes:
+        strategy = strategy_class()
+        trader.set_strategy(strategy)
+        health = trader.check_strategy_runtime_health()
+        assert health["ok"], f"{health['strategy']} health failed: {health['message']}"

--- a/tests/test_orderflow_pullback_strategy.py
+++ b/tests/test_orderflow_pullback_strategy.py
@@ -111,3 +111,12 @@ def test_orderflow_wool_strategy_can_add_short_and_close_on_pullback():
     add_trades = [t for t in result.trades if t.side == "ADD_SHORT"]
     assert len(add_trades) >= 1
     assert any(t.side == "short" for t in result.completed_trades)
+
+
+def test_orderflow_pullback_exposes_volume_filter_parameters_for_optimizer():
+    strategy = get_strategy("OrderFlowPullbackStrategy")
+    info = strategy.get_info()
+    param_names = {p["name"] for p in info["parameters"]}
+
+    assert "min_volume_ratio" in param_names
+    assert "max_volume_ratio" in param_names

--- a/tests/test_parameter_optimizer.py
+++ b/tests/test_parameter_optimizer.py
@@ -259,3 +259,14 @@ class TestGetParameterRangesFromStrategy:
         
         range_names = [r.name for r in ranges]
         assert "vote_threshold" in range_names
+
+
+def test_orderflow_float_params_use_finer_step():
+    from Strategy.templates import get_strategy
+
+    strategy = get_strategy("OrderFlowWoolStrategy")
+    ranges = get_parameter_ranges_from_strategy(strategy)
+    step_map = {r.name: r.step for r in ranges}
+
+    assert step_map["pullback_take_profit_pct"] <= 0.1
+    assert step_map["momentum_gap_boost"] <= 0.1

--- a/tests/test_second_interval_and_live_orderflow.py
+++ b/tests/test_second_interval_and_live_orderflow.py
@@ -1,0 +1,48 @@
+from datetime import datetime, timezone
+
+import pandas as pd
+
+from Data.data_service import UnifiedDataService, DataServiceConfig
+from Trading.live_trader import LiveTrader, TradingConfig, TradingMode
+from Strategy.templates import get_strategy
+
+
+def test_second_interval_aggregation_from_trades():
+    service = UnifiedDataService(DataServiceConfig(prefer_database=False, auto_init=False))
+
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    # 构造2分钟成交，覆盖1s/5s/15s聚合
+    fake_trades = []
+    for i in range(120):
+        t_ms = now_ms - (120 - i) * 1000
+        fake_trades.append({"T": t_ms, "p": str(100 + i * 0.01), "q": "5"})
+
+    service._fetch_agg_trades = lambda symbol, start_time_ms, end_time_ms, limit=1000: fake_trades
+
+    df_1s = service.get_second_klines_from_api("BTCUSDT", "1s", limit=30)
+    df_5s = service.get_second_klines_from_api("BTCUSDT", "5s", limit=30)
+    df_15s = service.get_second_klines_from_api("BTCUSDT", "15s", limit=30)
+
+    assert not df_1s.empty
+    assert not df_5s.empty
+    assert not df_15s.empty
+    assert len(df_1s) >= len(df_5s) >= len(df_15s)
+
+
+def test_orderflow_strategy_runs_in_realtime_simulation_mode():
+    trader = LiveTrader(TradingConfig(mode=TradingMode.TEST, symbol="BTCUSDT", interval="1s"))
+    strategy = get_strategy("OrderFlowWoolStrategy", {
+        "momentum_bars": 3,
+        "overbought_rsi": 55,
+        "min_volume_ratio": 0.6,
+        "max_volume_ratio": 10.0,
+    })
+    trader.set_strategy(strategy)
+
+    for _ in range(80):
+        trader._execute_orderflow_realtime()
+
+    buf = trader._realtime_buffers.get("BTCUSDT")
+    assert buf is not None
+    assert len(buf) > 50
+    assert isinstance(pd.DataFrame(list(buf)), pd.DataFrame)


### PR DESCRIPTION
### Motivation
- Allow backtests at second-level intervals (`1s`, `5s`, `15s`) and enable realistic testnet/simulated realtime runs for orderflow strategies which must react to trades/orderflow rather than periodic K-line polling. 
- Make orderflow strategies usable in a simulated live/test environment by feeding them high-frequency synthetic market/orderflow data. 
- Expose/adjust orderflow-related parameters and improve optimizer granularity for float/ratio parameters to help find robust settings.

### Description
- Data service: added `SECOND_INTERVAL_TO_SECONDS` and implemented `get_second_klines_from_api` that constructs second-level OHLCV by aggregating futures aggregate trades and resampling to `1s/5s/15s`, and wired second-level path into `get_klines` so backtests can request `1s/5s/15s` directly (`Data/data_service.py`).
- Live trader: implemented a realtime orderflow execution path that obtains an orderflow snapshot (book + recent trades) and appends synthetic tick/bars into an in-memory buffer, and added a `TEST`-mode simulated snapshot generator so testnet/simulated runs can exercise orderflow strategies continuously; trading loop sleep is made interval-aware and orderflow strategies trigger the realtime path instead of waiting for coarse K-line polling (`Trading/live_trader.py`).
- Strategy templates: added `min_volume_ratio` / `max_volume_ratio` parameters and integrated volume-ratio filtering into `OrderFlowPullbackStrategy`, and tuned defaults for `OrderFlowWoolStrategy` to improve backtest behavior (`Strategy/templates/__init__.py`).
- Parameter optimizer: float parameter step logic tightened for orderflow-related float keys (containing `_pct`, `_ratio`, `_boost`) to use finer step sizes (max `0.1`) to improve granularity during searches (`Strategy/parameter_optimizer.py`).
- UI: added `1s/5s/15s` options to the interval list and a compact window mode toggle to the header (`UI/main_ui.py`).
- Tests: added `tests/test_second_interval_and_live_orderflow.py` to validate second-level aggregation and simulated realtime orderflow buffering, extended live-health and orderflow strategy tests to cover the new parameters and optimizer behavior (`tests/...`).

### Testing
- Successfully compiled the modified modules with `python -m py_compile Data/data_service.py Trading/live_trader.py UI/main_ui.py tests/test_second_interval_and_live_orderflow.py` (no syntax errors).
- Ran `PYTHONPATH=. pytest -q tests/test_second_interval_and_live_orderflow.py` but collection failed due to missing runtime dependency `pandas` in the current environment (test code and new data-service functions rely on `pandas` and real/aggregate trade API responses).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69986b485ee48324b66a1272d0d5e165)